### PR TITLE
Adds `.keep_next` paragraph property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ docx.p 'Sample text.' do
   bgcolor         'cccccc'          # sets the background color.
   highlight_color 'yellow'          # sets the highlight color. only accepts OOXML enumerations. see http://www.datypic.com/sc/ooxml/t-w_ST_HighlightColor.html.
   vertical_align  'superscript'     # sets the vertical alignment.
+  keep_next       false             # sets whether or not to keep this paragraph with the next paragraph when separated by page break.
 end
 ```
 

--- a/lib/caracal/core/models/paragraph_model.rb
+++ b/lib/caracal/core/models/paragraph_model.rb
@@ -28,6 +28,7 @@ module Caracal
         attr_reader :paragraph_italic
         attr_reader :paragraph_underline
         attr_reader :paragraph_bgcolor
+        attr_reader :paragraph_keep_next
 
         # initialization
         def initialize(options={}, &block)
@@ -64,7 +65,7 @@ module Caracal
         #========== SETTERS ===============================
 
         # booleans
-        [:bold, :italic, :underline].each do |m|
+        [:bold, :italic, :keep_next, :underline].each do |m|
           define_method "#{ m }" do |value|
             instance_variable_set("@paragraph_#{ m }", !!value)
           end

--- a/lib/caracal/renderers/document_renderer.rb
+++ b/lib/caracal/renderers/document_renderer.rb
@@ -290,6 +290,7 @@ module Caracal
             xml['w'].pStyle({ 'w:val' => model.paragraph_style })  unless model.paragraph_style.nil?
             xml['w'].contextualSpacing({ 'w:val' => '0' })
             xml['w'].jc({ 'w:val' => model.paragraph_align })  unless model.paragraph_align.nil?
+            xml['w'].keepNext if model.paragraph_keep_next == true
             render_run_attributes(xml, model, true)
           end
           model.runs.each do |run|

--- a/spec/lib/caracal/core/models/paragraph_model_spec.rb
+++ b/spec/lib/caracal/core/models/paragraph_model_spec.rb
@@ -11,6 +11,7 @@ describe Caracal::Core::Models::ParagraphModel do
       italic      false
       underline   true
       bgcolor     'cccccc'
+      keep_next   true
     end
   end
 
@@ -31,6 +32,7 @@ describe Caracal::Core::Models::ParagraphModel do
       it { expect(subject.paragraph_italic).to eq false }
       it { expect(subject.paragraph_underline).to eq true }
       it { expect(subject.paragraph_bgcolor).to eq 'cccccc' }
+      it { expect(subject.paragraph_keep_next).to eq true }
     end
 
   end
@@ -69,6 +71,11 @@ describe Caracal::Core::Models::ParagraphModel do
       before { subject.italic(true) }
 
       it { expect(subject.paragraph_italic).to eq true }
+    end
+    describe '.keep_next' do
+      before { subject.keep_next(true) }
+
+      it { expect(subject.paragraph_keep_next).to eq true }
     end
     describe '.underline' do
       before { subject.underline(true) }


### PR DESCRIPTION
[TP Link](https://clearchanneloutdoor.tpondemand.com/entity/25859-vault-on-page-break-table-header)

> Specifies that the paragraph (or at least part of it) should be
rendered on the same page as the next paragraph when possible. It is an
empty element: <w:keepNext/>. If multiple paragraphs are to be kept
together but they exceed a page, then the set of paragraphs begin on a
new page and page breaks are used thereafter as needed.

http://officeopenxml.com/WPparagraphProperties.php

Usage

```
context.p 'hi' do
  keep_next true
end
```